### PR TITLE
[ REFACT ] Exams Tests Endpoint Resource Not Found Error

### DIFF
--- a/app/frontend/src/public/css/main.css
+++ b/app/frontend/src/public/css/main.css
@@ -6,6 +6,7 @@ body {
 	text-align: center;
 	width: 70%;
 	margin-right: auto;
+  margin-top: 1rem;
 	margin-left: auto;
 }
 

--- a/app/frontend/src/public/js/ExamDetailView.js
+++ b/app/frontend/src/public/js/ExamDetailView.js
@@ -13,14 +13,20 @@ export default class extends AbstractView {
       fetch(this.URL + `?token=${this.params.token}`)
         .then((response) => {
           if (response.status === 500) throw new Error('An error has ocurred. Try again');
+          if (response.status == 404) {
+            notice.classList.add('alert', 'alert-warning');
+            notice.innerText = 'Exame não encontrado.'
+          }
           return response.json();
         })
         .then((data) => {
-          const descriptionList = this.createExamsDescriptionList(data);
-          const tableTests = this.createTestsTable(data);
-
-          fragment.appendChild(descriptionList);
-          fragment.appendChild(tableTests);
+          if (data.length) {
+            const descriptionList = this.createExamsDescriptionList(data);
+            const tableTests = this.createTestsTable(data);
+  
+            fragment.appendChild(descriptionList);
+            fragment.appendChild(tableTests);
+          }
         })
         .catch((error) => {
           console.error(error);

--- a/app/frontend/src/public/js/ExamsView.js
+++ b/app/frontend/src/public/js/ExamsView.js
@@ -15,14 +15,20 @@ export default class extends AbstractView {
     return new Promise((resolve, _reject) => {
       fetch(this.URL)
         .then((response) => {
+          if (response.status === 404) {
+            notice.classList.add('alert', 'alert-warning');
+            notice.innerText = 'Não há exames cadastrados.'
+            return response.json();
+          }
           if (response.status === 500) throw new Error('An error has ocurred. Try again');
           return response.json();
         })
         .then((data) => {
-          const table = this.createTable(data);
-
-          fragment.appendChild(heading1);
-          fragment.appendChild(table);
+          if (data.length) {
+            const table = this.createTable(data);
+            fragment.appendChild(heading1);
+            fragment.appendChild(table);
+          }
         })
         .catch((error) => {
           console.error(error.message);

--- a/app/frontend/src/public/js/SearchView.js
+++ b/app/frontend/src/public/js/SearchView.js
@@ -50,13 +50,14 @@ export default class extends AbstractView {
         fetch(this.URL + `?token=${token}`)
           .then((response) => {
             if (response.status === 500) throw new Error('An error has ocurred. Try again');
+            if (response.status == 404) {
+              notice.classList.add('alert', 'alert-warning');
+              notice.innerText = 'Exame não encontrado.'
+            }
             return response.json();
           })
           .then((data) => {
-            if (data.length == 0) {
-              notice.classList.add('alert', 'alert-warning');
-              notice.innerText = 'Exame não encontrado.'
-            } else {
+            if (data.length) {
               const descriptionList = this.examDetailView.createExamsDescriptionList(data);
               const tableTests = this.examDetailView.createTestsTable(data);
               article.appendChild(descriptionList)

--- a/app/frontend/src/server.rb
+++ b/app/frontend/src/server.rb
@@ -1,5 +1,6 @@
 require 'rack/handler/puma'
 require 'sinatra'
+require 'faraday'
 require_relative './services/upload_csv_service.rb'
 require_relative './services/api_service.rb'
 
@@ -35,6 +36,15 @@ get '/data' do
     else
       response = ApiService.get_exams(conn)
     end
+
+    response.body
+
+  rescue Faraday::ResourceNotFound => e
+    puts '------------- Frontend Error GET /data ---------------'
+    puts e
+
+    status 404
+    return [].to_json
   rescue Faraday::ServerError, Faraday::Connection, Faraday::ConnectionFailed => e
     puts '------------- Frontend Error GET /data ---------------'
     puts e
@@ -43,8 +53,6 @@ get '/data' do
     return { error: true,  message: 'An error has occurred. Try again' }.to_json
   end
 
-  status 200
-  response.body
 end
 
 # This route is used to upload the CSV file to the backend

--- a/app/frontend/src/spec/system/search_page_spec.rb
+++ b/app/frontend/src/spec/system/search_page_spec.rb
@@ -85,13 +85,14 @@ RSpec.describe 'User visits search page', type: :feature, js: true do
     mock_conn = instance_double(Faraday::Connection)
     mock_response = instance_double(Faraday::Response)
 
+    token = 'foo'
+
     allow(ApiService).to receive(:connection).and_return(mock_conn)
-    allow(ApiService).to receive(:get_exam_by_token).with(mock_conn, 'blablabla').and_return(mock_response)
-    allow(mock_response).to receive(:body).and_return([].to_json)
+    allow(ApiService).to receive(:get_exam_by_token).with(mock_conn, token).and_raise(Faraday::ResourceNotFound)
 
     visit '/search'
 
-    fill_in 'token', with: 'blablabla'
+    fill_in 'token', with: token
     click_button 'Pesquisar'
 
     expect(page).to have_content 'Exame não encontrado.'


### PR DESCRIPTION
With this PR, I have achieved the following:

- [x] when an exam is not found, the back and front servers endpoint returns a 404 status code and an empty array;
- [x] added server side error handling in the /tests back endpoint., returning a status 500 case it happens.
- [x] refactored views to handle this new types of response of status 404 and show an alert in the page;
- [x] refactored tests files to assert this 404 responses;